### PR TITLE
Whether to log job history within Redis

### DIFF
--- a/lib/robot-master/queue.rb
+++ b/lib/robot-master/queue.rb
@@ -66,6 +66,10 @@ module RobotMaster
       # perform the enqueue to Resque
       ROBOT_LOG.debug { "enqueue_to: #{queue} #{klass} #{druid}" }
       Resque.enqueue_to(queue.to_sym, klass, druid)
+      
+      if opts[:logging]
+        Resque.enqueue_to('history', queue, klass, druid, Time.now)
+      end
   
       { :queue => queue, :klass => klass }
     end

--- a/lib/robot-master/workflow.rb
+++ b/lib/robot-master/workflow.rb
@@ -168,7 +168,7 @@ module RobotMaster
       results.each do |druid, priority|
         begin # XXX preferably within atomic transaction
           mark_enqueued(step, druid)
-          Queue.enqueue(step, druid, Priority.priority_class(priority))
+          Queue.enqueue(step, druid, Priority.priority_class(priority), logging: process[:logging])
           n += 1
         rescue => e
           ROBOT_LOG.warn("Cannot enqueue job: #{step} #{druid} #{priority}: #{e}")
@@ -229,7 +229,8 @@ module RobotMaster
         :name => name, 
         :prereq => prereqs, 
         :skip => skip,
-        :limit => (node['queue-limit'] ? node['queue-limit'].to_i : nil )
+        :limit => (node['queue-limit'] ? node['queue-limit'].to_i : nil ),
+        :logging => ((node['skip-logging'] == 'true') ? false : true)
       }
     end
     


### PR DESCRIPTION
We might want to do this in the Workflow service instead -- make a simple way to query history, rather than fetching each and every druid workflow.xml.
