### PR TITLE
switch status board to use Faraday persistent connections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'dor-services', '~> 5.5'
 gem 'lyber-core', '~> 4.0'
 gem 'parallel', '~> 1.2'
 gem 'whenever'
+gem 'faraday'
 
 group :development do
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-services (~> 5.5)
   equivalent-xml
+  faraday
   lyber-core (~> 4.0)
   mock_redis
   nokogiri (~> 1.6.8)

--- a/lib/robot-master/status_board.rb
+++ b/lib/robot-master/status_board.rb
@@ -1,22 +1,20 @@
 require 'awesome_print'
 require 'nokogiri'
-require 'restclient'
+require 'faraday'
 require 'parallel'
 
 class RobotStatusBoard
-  def count_ready(wq_uri, step, prereq, lane)
-    uri = "#{wq_uri}?waiting=#{step}&completed=#{prereq}&lane-id=#{lane}&count-only=true"
-    resource = RestClient::Resource.new(uri, timeout: 60)
-    xml = resource.get
+  def count_ready(conn, step, prereq, lane)
+    uri = "?waiting=#{step}&completed=#{prereq}&lane-id=#{lane}&count-only=true"
+    xml = conn.get(uri).body
     doc = Nokogiri::XML(xml)
     doc.root['count'].to_i
   end
 
-  def count_status(wq_uri, step, lane, type)
+  def count_status(conn, step, lane, type)
     r, w, s = step.split(/:/)
-    uri = "#{wq_uri}?repository=#{r}&workflow=#{w}&#{type}=#{s}&lane-id=#{lane}&count-only=true"
-    resource = RestClient::Resource.new(uri, timeout: 60)
-    xml = resource.get
+    uri = "?repository=#{r}&workflow=#{w}&#{type}=#{s}&lane-id=#{lane}&count-only=true"
+    xml = conn.get(uri).body
     doc = Nokogiri::XML(xml)
     doc.root['count'].to_i
   end
@@ -27,20 +25,23 @@ class RobotStatusBoard
     fn = "config/workflows/#{repo}/#{wf}.xml"
     return unless File.exist?(fn)
     doc = Nokogiri::XML(File.read(fn))
+    conn = Faraday.new(wq_uri) do |faraday|
+      faraday.adapter :net_http_persistent
+    end
     Parallel.map(doc.root.xpath('.//process'), in_threads: 10) do |p|
       step = p['name']
       fstep = [repo, wf, step].join(':')
       STDERR.puts "Processing step #{step}" if flags[:debug]
       status[step] = {}
-      n = count_status(wq_uri, fstep, lane, 'waiting')
+      n = count_status(conn, fstep, lane, 'waiting')
       status[step][:waiting] = n
       status[step][:ready] = n # assuming no prereqs
       p.xpath('prereq/text()').each do |pr| # XXX: assuming single prereq
-        n = count_ready(wq_uri, fstep, [repo, wf, pr.to_s].join(':'), lane)
+        n = count_ready(conn, fstep, [repo, wf, pr.to_s].join(':'), lane)
         status[step][:ready] = n
       end
       %w(error queued completed).each do |s|
-        status[step][s.to_sym] = count_status(wq_uri, fstep, lane, s)
+        status[step][s.to_sym] = count_status(conn, fstep, lane, s)
       end
     end
     # ap({:status => status})


### PR DESCRIPTION
This PR fixes #76. The status board is slooooow and this PR speeds it up 5x or so.