### PR TITLE
upgrade to dor-services 5.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,34 +1,35 @@
 source 'https://rubygems.org'
 
-gem 'nokogiri', '~> 1.6.8'
-gem 'resque', '~> 1.25.2'
-gem 'robot-controller', '~> 2.0.0'
-gem 'awesome_print', '~> 1.2'
-gem 'dor-services', '~> 5.5'
-gem 'lyber-core', '~> 4.0'
-gem 'parallel', '~> 1.2'
+gem 'awesome_print'
+gem 'nokogiri'
+gem 'parallel'
+gem 'resque'
 gem 'whenever'
 gem 'faraday'
 
-group :development do
+gem 'dor-services', '>= 5.8.2'
+gem 'lyber-core', '>= 4.0.3'
+gem 'robot-controller', '>= 2.0.1'
+
+group :development, :test do
   gem 'equivalent-xml'
   gem 'mock_redis'
-  gem 'resque-mock'
   gem 'pry'
   gem 'rake'
   gem 'rdoc'
   gem 'redcarpet' # provides Markdown
+  gem 'resque-mock'
   gem 'rspec'
+  gem 'rubocop'
   gem 'simplecov'
   gem 'version_bumper'
   gem 'yard'
-  gem 'rubocop'
 end
 
 group :deployment do
-  gem 'capistrano', '~> 3.0'
-  gem 'capistrano-bundler', '~> 1.1'
-  gem 'capistrano-rvm'
+  gem 'capistrano-bundler'
   gem 'capistrano-passenger'
-  gem 'dlss-capistrano', '~> 3.1'
+  gem 'capistrano-rvm'
+  gem 'capistrano'
+  gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,22 +11,24 @@ GEM
       rdf-rdfxml (= 1.0.1)
       rsolr
       rubydora (~> 1.6, >= 1.6.5)
-    activemodel (4.2.5.2)
-      activesupport (= 4.2.5.2)
+    activemodel (4.2.7)
+      activesupport (= 4.2.7)
       builder (~> 3.1)
-    activesupport (4.2.5.2)
+    activesupport (4.2.7)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.2.0)
-    awesome_print (1.6.1)
+    airbrussh (1.0.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    ast (2.3.0)
+    awesome_print (1.7.0)
     bagit (0.3.2)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     blue-daemons (1.1.11)
-    bluepill (0.1.1)
+    bluepill (0.1.2)
       activesupport (>= 3.2, < 5)
       blue-daemons (~> 1.1)
       state_machine (~> 1.1)
@@ -34,16 +36,19 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    capistrano (3.4.0)
+    capistrano (3.5.0)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
-    capistrano-bundle_audit (0.0.5)
-      bundler-audit
+      sshkit (>= 1.9.0)
+    capistrano-bundle_audit (0.1.0)
+      bundler-audit (~> 0.5)
       capistrano (~> 3.0)
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
+    capistrano-harrow (0.5.2)
     capistrano-one_time_key (0.0.1)
       capistrano (~> 3.0)
     capistrano-passenger (0.2.0)
@@ -57,26 +62,26 @@ GEM
     coderay (1.1.1)
     confstruct (0.2.7)
     daemons (1.2.3)
-    deprecation (0.2.2)
+    deprecation (1.0.0)
       activesupport
     diff-lcs (1.2.5)
-    dlss-capistrano (3.2.0)
+    dlss-capistrano (3.3.0)
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.0.3)
+      capistrano-bundle_audit (>= 0.1.0)
       capistrano-one_time_key
       capistrano-releaseboard
     docile (1.1.5)
     docopt (0.5.0)
-    domain_name (0.5.20160216)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.0.2)
+    dor-rights-auth (1.2.0)
       nokogiri
-    dor-services (5.5.0)
+    dor-services (5.8.2)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
       dor-rights-auth (~> 1.0, >= 1.0.2)
-      dor-workflow-service (~> 2.0)
+      dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
@@ -85,7 +90,6 @@ GEM
       modsulator (~> 0.0.7)
       net-sftp (~> 2.1)
       nokogiri (~> 1.6)
-      nokogiri-pretty (~> 0.1)
       om (~> 3.0)
       rdf (~> 1.1.7)
       rest-client (~> 1.7)
@@ -116,7 +120,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    iso-639 (0.2.5)
+    iso-639 (0.2.8)
     json (1.8.3)
     link_header (0.0.8)
     lyber-core (4.0.3)
@@ -129,16 +133,16 @@ GEM
       validatable
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile2 (2.1.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     moab-versioning (2.0.0)
       confstruct
       json
       nokogiri
       nokogiri-happymapper
       systemu
-    mock_redis (0.16.0)
+    mock_redis (0.16.1)
     mods (2.0.3)
       iso-639
       nokogiri
@@ -149,22 +153,20 @@ GEM
       nokogiri
       roo (>= 1.1)
     mono_logger (1.1.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (3.2.0)
     netrc (0.11.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nokogiri-pretty (0.1.0)
-      nokogiri
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -176,12 +178,12 @@ GEM
       mediashelf-loggable
       nokogiri (>= 1.4.2)
       solrizer (~> 3.1.0)
-    parallel (1.6.2)
-    parser (2.3.0.6)
+    parallel (1.9.0)
+    parser (2.3.1.2)
       ast (~> 2.2)
     pkg-config (1.1.7)
     powerpack (0.1.1)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -200,7 +202,7 @@ GEM
     rdoc (4.2.2)
       json (~> 1.4)
     redcarpet (3.3.4)
-    redis (3.2.2)
+    redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
@@ -221,35 +223,35 @@ GEM
       rake (~> 10.3)
       resque (~> 1.25.2)
       whenever (~> 0.9.2)
-    roo (2.3.2)
+    roo (2.4.0)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.1.1)
       builder (>= 2.1.2)
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.3)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.1)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    rubocop (0.37.2)
-      parser (>= 2.3.0.4, < 3.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubocop (0.41.2)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 0.3)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-cache (0.3.0)
     ruby-graphviz (1.2.2)
-    ruby-progressbar (1.7.5)
+    ruby-progressbar (1.8.1)
     rubydora (1.6.5)
       activemodel
       activesupport
@@ -261,9 +263,9 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.2.0)
-    simplecov (0.11.2)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     sinatra (1.4.7)
@@ -278,59 +280,59 @@ GEM
       nokogiri
       stomp
       xml-simple
-    sshkit (1.8.1)
+    sshkit (1.11.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stanford-mods (1.5.3)
       activesupport
       mods (~> 2.0.2)
     state_machine (1.2.0)
-    stomp (1.3.5)
+    stomp (1.4.1)
     systemu (2.6.5)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (0.3.1)
+    unicode-display_width (1.1.0)
     uuidtools (2.1.5)
     validatable (1.6.7)
     vegas (0.1.11)
       rack (>= 1.0.0)
     version_bumper (0.3.0)
-    whenever (0.9.4)
+    whenever (0.9.7)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
-    yard (0.8.7.6)
+    yard (0.9.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print (~> 1.2)
-  capistrano (~> 3.0)
-  capistrano-bundler (~> 1.1)
+  awesome_print
+  capistrano
+  capistrano-bundler
   capistrano-passenger
   capistrano-rvm
-  dlss-capistrano (~> 3.1)
-  dor-services (~> 5.5)
+  dlss-capistrano
+  dor-services (>= 5.8.2)
   equivalent-xml
   faraday
-  lyber-core (~> 4.0)
+  lyber-core (>= 4.0.3)
   mock_redis
-  nokogiri (~> 1.6.8)
-  parallel (~> 1.2)
+  nokogiri
+  parallel
   pry
   rake
   rdoc
   redcarpet
-  resque (~> 1.25.2)
+  resque
   resque-mock
-  robot-controller (~> 2.0.0)
+  robot-controller (>= 2.0.1)
   rspec
   rubocop
   simplecov


### PR DESCRIPTION
This PR upgrades dor-services to 5.8.2 and removes unneeded pins in the `Gemfile`