### PR TITLE
Use solr rather than solrizer config

### DIFF
--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -1,7 +1,7 @@
 cert_dir = File.join(File.dirname(__FILE__), '..', 'certs')
 
 Dor::Config.configure do
-  solrizer.url 'http://example.com/solr/collection'
+  solr.url 'http://example.com/solr/collection'
   fedora.url 'https://example.com/fedora'
 
   ssl do


### PR DESCRIPTION
This avoids the deprecation:
```
DEPRECATION WARNING: Dor::Config -- solrizer configuration is deprecated. Please use solr instead.
```