### PR TITLE
Skip downloading the digitizationWF and sdrIngestWF

### DIFF
--- a/bin/robot-download-workflows
+++ b/bin/robot-download-workflows
@@ -39,12 +39,15 @@ end
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 RobotDownloadWorkflowsCLI.new('config/workflows').run
 
-# XXX: skip these workflows no matter what
+# Skip these workflows, we don't want them to run robots
+# these workflows are defunct.
 skipfiles = %w(
+  dor/digitizationWF.xml
   dor/dpgImageWF.xml
   dor/eemsAccessionWF.xml
   dor/googleScannedBookWF.xml
   dor/hydrusAssemblyWF.xml
+  sdr/sdrIngestWF.xml
 ).each do |fn|
   path = Pathname("config/workflows/#{fn}")
   if path.exist?


### PR DESCRIPTION
These workflows are defunct and have been replaced by goobiWF and
 preservationIngestWF respectively.  This will reduce the load on the
workflow server because it won't ask it every 15s for jobs that need to
be enqued for those workflows